### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ commands\cp.com: commands\cp.obj
 commands\date.com: commands\date.obj
 	$(LD) $(LDFLAGS) system com file $?
 
-commands\dirname.com: commands\dirname.obj lib\getopt.obj lib\dirnamel.obj lib\basenaml.obj
-	$(LD) $(LDFLAGS) system com file {$?}
+commands\dirname.com: 
+	$(LD) $(LDFLAGS) system com file commands\dirname.obj, lib\getopt.obj, lib\dirnamel.obj, lib\basenaml.obj
 
 commands\echo.com: commands\echo.obj
 	$(LD) $(LDFLAGS) system com file $?


### PR DESCRIPTION
This modification will allow dirname to be built properly without having * before wcc and wlink